### PR TITLE
Let only one device send invitation to reconnect devices more robustly

### DIFF
--- a/Sources/MultiPeer.swift
+++ b/Sources/MultiPeer.swift
@@ -216,7 +216,11 @@ extension MultiPeer: MCNearbyServiceBrowserDelegate {
         // Update the list of available peers
         availablePeers.append(Peer(peerID: peerID, state: .notConnected))
 
-        browser.invitePeer(peerID, to: session, withContext: nil, timeout: connectionTimeout)
+        // Ensure only one device send invitation
+        // https://stackoverflow.com/questions/19469984/reconnecting-to-disconnected-peers
+        if devicePeerID.displayName > peerID.displayName {
+            browser.invitePeer(peerID, to: session, withContext: nil, timeout: connectionTimeout)
+        }
     }
 
     /// Lost a peer, update the list of available peers


### PR DESCRIPTION
According to [ChrisH's solution](https://stackoverflow.com/questions/19469984/reconnecting-to-disconnected-peers), let only one device send invitation to reconnect devices more robustly.