### PR TITLE
Invite peer manually

### DIFF
--- a/Sources/MultiPeer.swift
+++ b/Sources/MultiPeer.swift
@@ -178,6 +178,10 @@ public class MultiPeer: NSObject {
             }
         }
     }
+    
+    public func invite(peer: Peer, context: Data? = nil) {
+        self.serviceBrowser.invitePeer(peer.peerID, to: session, withContext: context, timeout: connectionTimeout)
+    }
 
     /** Prints only if in debug mode */
     fileprivate func printDebug(_ string: String) {
@@ -213,10 +217,13 @@ extension MultiPeer: MCNearbyServiceBrowserDelegate {
     public func browser(_ browser: MCNearbyServiceBrowser, foundPeer peerID: MCPeerID, withDiscoveryInfo info: [String: String]?) {
         printDebug("Found peer: \(peerID)")
 
+        let peer = Peer(peerID: peerID, state: .notConnected)
         // Update the list of available peers
-        availablePeers.append(Peer(peerID: peerID, state: .notConnected))
+        availablePeers.append(peer)
 
-        browser.invitePeer(peerID, to: session, withContext: nil, timeout: connectionTimeout)
+        if self.delegate?.multiPeer(shouldInvitePeerDidFound: peerID, browser: browser, withDiscoveryInfo: info) ?? true {
+            invite(peer: peer)
+        }
     }
 
     /// Lost a peer, update the list of available peers

--- a/Sources/MultiPeerDelegate.swift
+++ b/Sources/MultiPeerDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import MultipeerConnectivity
 
 /// MultiPeerDelegate
 ///
@@ -21,5 +22,7 @@ public protocol MultiPeerDelegate: class {
 
     /// connectedDevicesChanged: delegate runs on connection/disconnection event in session
     func multiPeer(connectedDevicesChanged devices: [String])
+    
+    func multiPeer(shouldInvitePeerDidFound peerID: MCPeerID, browser: MCNearbyServiceBrowser, withDiscoveryInfo info: [String: String]?) -> Bool
 
 }


### PR DESCRIPTION
Add shouldInvitePeerDidFound delegate and expose invite peer method to make developer invite peer manually. If there is no delegate, then auto invite peer and [reconnect issue](https://stackoverflow.com/questions/19469984/reconnecting-to-disconnected-peers) is possible to be raised.