### PR TITLE
Added source peer on MultipeerDelegate didReceveData method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ MultiPeer.instance.send(object: "Hello World!", type: DataType.string.rawValue)
 To receive data, we must conform to the `MultiPeerDelegate` protocol:
 
 ```swift
-func multiPeer(didReceiveData data: Data, ofType type: UInt32) {
+func multiPeer(didReceiveData data: Data, ofType type: UInt32, from peerID: MCPeerID) {
   switch type {
     case DataType.string.rawValue:
       let string = data.convert() as! String

--- a/Sources/MultiPeer.swift
+++ b/Sources/MultiPeer.swift
@@ -267,7 +267,7 @@ extension MultiPeer: MCSessionDelegate {
         guard let type = container[1] as? UInt32 else { return }
 
         OperationQueue.main.addOperation {
-            self.delegate?.multiPeer(didReceiveData: item, ofType: type)
+            self.delegate?.multiPeer(didReceiveData: item, ofType: type, from: peerID)
         }
 
     }

--- a/Sources/MultiPeerDelegate.swift
+++ b/Sources/MultiPeerDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import MultipeerConnectivity
 
 /// MultiPeerDelegate
 ///
@@ -14,10 +15,10 @@ import Foundation
 /// multiPeer(didRecieveData: Data, ofType: UInt32)
 /// multiPeer(connectedDevicesChanged: [String])
 
+public typealias MCPeerID = MultipeerConnectivity.MCPeerID
 public protocol MultiPeerDelegate: class {
-
     /// didReceiveData: delegate runs on receiving data from another peer
-    func multiPeer(didReceiveData data: Data, ofType type: UInt32)
+    func multiPeer(didReceiveData data: Data, ofType type: UInt32, from peerID: MCPeerID)
 
     /// connectedDevicesChanged: delegate runs on connection/disconnection event in session
     func multiPeer(connectedDevicesChanged devices: [String])


### PR DESCRIPTION
This PR exposes source peer when data is received.
It's useful when you want to forward a message to other peers, excluding source peer to avoid loops/duplication